### PR TITLE
use list comparison is better

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -90,11 +90,12 @@ if __name__ == '__main__':
     parameters = TrainingParameters(**json.loads(args.parameters))
 
     # Arrange label definition (when nonconsecutive)
-    labels = np.unique(train_masks)
+    labels = list(np.unique(train_masks))
     num_classes = len(labels) - 1
     labels = labels[1:]      # remove non-labeled pixels
+    ordered_labels = list(range(num_classes))
     tmp = np.copy(train_masks)
-    if not (labels == np.arange(num_classes)).all():
+    if not labels == ordered_labels:
         for count, label in enumerate(labels):
             train_masks[tmp==label] = count
     else:


### PR DESCRIPTION
Sorry, I tested again this after accepting your PR. I still think using built-in list comparison is better because element-wise comparison for array with different length (which is not our case) will be depreciated in Numpy module. 

>>> import numpy as np
>>> a = np.arange(5)
>>> b = np.arange(1,6)
>>> a
array([0, 1, 2, 3, 4])
>>> b
array([1, 2, 3, 4, 5])
>>> (a==b).all()
False
>>> b = np.arange(6)
>>> (a==b).all()
__main__:1: DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'bool' object has no attribute 'all'
>>> 